### PR TITLE
Include homepage in project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
   "python-keycloak",
 ]
 
+[project.urls]
+Homepage = "https://github.com/PatrykGrzybowski/DestinE_auth"
+
 [project.optional-dependencies]
 dev = [
   "python-dotenv", 


### PR DESCRIPTION
Add homepage URL to project metadata. Makes the source easily discoverable from PyPI.